### PR TITLE
Fix: remove ObjectId to avoid error

### DIFF
--- a/backend/router/router.py
+++ b/backend/router/router.py
@@ -41,22 +41,15 @@ def signin():
     if "uid" in session:
             return jsonify({'message':'success'})
     else:
-        if request.method == 'GET':
-            print('already in session')
+        if request.method == 'GET': 
             return jsonify({'message':'signin'})
         else:
-            print(request.method)
             uid = request.form['uid']
-            print(uid)
             pwd = request.form['pwd']
-            print(pwd)
             if s.verify(uid, pwd):
-                print("valid")
                 session["uid"] = uid
-                print(uid)
                 return jsonify({'message':'success'})
             else:
-                print("invalid")
                 return jsonify({'message':'fail'})
 
 @bp.route("/logout")
@@ -72,13 +65,15 @@ def logout():
 @cross_origin(supports_credentials=True)
 def finder(id):
     files = s.check_dir(session["uid"], int(id))
-    print(session['uid'])
-    print(id)
     if isinstance(files, list):
+        for f in files:
+            f["fileid"] = None
         return jsonify({'message':'dir', 'files':files, 'cdi':int(id), 'uid':session['uid']})
     elif isinstance(files, bool):
         return jsonify({'message':'empty', 'cdi':int(id), 'uid':session['uid']})
     else:
+        for f in files:
+            f["fileid"] = None
         return jsonify({'message':'file', 'id':int(id), 'file':files})
 
 @bp.route("/upload/<id>", methods=['POST'])


### PR DESCRIPTION
- MongoDB의 ObjectId 타입인 필드가 포함된 BSON을 JSON으로 변경 후 반환하기 위해 dumps 함수를 사용함
- ObjectId를 포함하는 리스트 전체에 dumps를 사용하자 리스트가 문자열로 바뀌어 반환 돼서 [5a8af5f](https://github.com/KNU-OSP-Team3/CoLearner/pull/22/commits/5a8af5f91687b15cab9db7f530867f3052defb8b) 에서 dumps를 제거
- 이후 같은 문제가 발생해 finder에서는 ObjectId 필드가 필요없다고 판단해 제거 후 반환함

Closes #25 