### PR TITLE
28 be guest 모드 upload viewer 구현

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -52,7 +52,6 @@ class Finder(Resource):
 @api.route("/upload/<id>")
 class Upload(Resource):
     @api.doc(responses={200:'성공',400:'서버 오류',404:'찾을 수 없음'})
-    @api.doc(params={})
     @api.doc(params={'id':'현재 디렉토리','file':{'type':'file','in':'formData','name':'file','description':'업로드 할 파일'}})
     def post(self, id):
         '''파일 업로드'''
@@ -60,7 +59,7 @@ class Upload(Resource):
 @api.route("/makedir/<id>")
 class Makedir(Resource):
     @api.doc(responses={200:'성공',400:'서버 오류',404:'찾을 수 없음'})
-    @api.doc(params={'dirname':'디렉토리 이름','id':'새 디렉토리를 생성할 디렉토리의 id'})
+    @api.doc(params={'dirname':{'type':'string','in':'formData','name':'dirname','description':'디렉토리 이름'},'id':'새 디렉토리를 생성할 디렉토리의 id'})
     def post(self, dirname, id):
         '''새 디렉토리 생성'''
 
@@ -77,6 +76,13 @@ class Receive(Resource):
     @api.doc(params={'id': '받을 파일의 id'})
     def get(self, id):
         '''파일 요청'''
+
+@api.route("/guest")
+class Guest(Resource):
+    @api.doc(responses={200:'성공',400:'서버 오류',404:'찾을 수 없음'})
+    @api.doc(params={'file':{'type':'file','in':'formData','name':'file','description':'업로드 할 파일'}})
+    def post(self):
+        '''비회원으로 파일 업로드'''
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=5000, debug=True)

--- a/backend/router/router.py
+++ b/backend/router/router.py
@@ -2,6 +2,7 @@ from flask import request, Blueprint, session, Response, jsonify, send_file
 from services import services as s
 from werkzeug.utils import secure_filename
 from flask_cors import CORS, cross_origin
+from base64 import b64encode
 
 bp = Blueprint("main", __name__, url_prefix="/")
 
@@ -122,7 +123,9 @@ def receive(id):
         if file:
             path = s.download(file)
             if path:
-                return send_file(path, as_attachment=True)
+                with open(path, "rb") as binary_file:
+                    encoded_string = b64encode(binary_file.read())
+                return jsonify({'message':'success', 'content':encoded_string.decode('utf-8')})
             else:
                 return jsonify({'message' : 'fail', 'error':'download'})    
         else:
@@ -142,6 +145,8 @@ def guest():
         "path" : filepath,
     }
     s.process_file(None, file_info)
-    return send_file(filepath, as_attachment=True)
+    with open(filepath, "rb") as binary_file:
+        encoded_string = b64encode(binary_file.read())
+    return jsonify({'message':'success', 'content':encoded_string.decode('utf-8')})
     
 

--- a/backend/router/router.py
+++ b/backend/router/router.py
@@ -75,9 +75,6 @@ def finder(id):
 @cross_origin(supports_credentials=True)
 def upload(id):
     f = request.files['file']
-    filepath = "./static/files/"+secure_filename(f.filename)
-    f.save(filepath)
-
     if "uid" in session:
         file = s.upload(session["uid"], secure_filename(f.filename), id)
         if file:
@@ -87,13 +84,8 @@ def upload(id):
                 return jsonify({'message':'fail', 'error':'process_file'})    
         else:
             return jsonify({'message':'fail', 'error':'upload'})
-    #Guest
     else:
-        file_info = {
-        "name" : f.filename.split(".")[0],
-        "type" : f.filename.split(".")[-1].upper(),
-        }
-        return jsonify({'message':'success', 'id':0, 'file_info':file_info})
+        return jsonify({'message':'fail', 'error':'not authorized'})
 
 @bp.route("/makedir/<id>", methods=['POST'])
 @cross_origin(supports_credentials=True)
@@ -119,14 +111,9 @@ def viewer(id, pagenum):
         
     # Guest
     else:
-        file_info = request.args['fileinfo']
-        pr, ft = s.read_file(file_info)
-        if pr == None or ft == None:
-            return jsonify({'message':'fail'})
-        else:
-            content = s.read_page(pr, int(pagenum), ft)
-            return jsonify({'message':'success','content':content})
-
+        links = s.get_link(None, None, pagenum)
+        return jsonify({'message':'success','links':links["links"]})
+        
 @bp.route("/receive/<id>", methods=['GET'])
 @cross_origin(supports_credentials=True)
 def receive(id):
@@ -142,3 +129,19 @@ def receive(id):
             return jsonify({'message' : 'fail', 'error':'get file'})    
     else:
         return jsonify({'message' : 'fail', 'error':'not authorized'})
+
+@bp.route("/guest", methods=['POST'])
+@cross_origin(supports_credentials=True)
+def guest():
+    f = request.files['file']
+    filepath = "./static/files/"+secure_filename(f.filename)
+    f.save(filepath)
+
+    file_info = {
+        "type" : f.filename.split(".")[-1].upper(),
+        "path" : filepath,
+    }
+    s.process_file(None, file_info)
+    return send_file(filepath, as_attachment=True)
+    
+


### PR DESCRIPTION
- Guest 페이지에 파일 업로드 시 링크들을 클라이언트 측에 임시 저장
- Guest는 회원 모드와 달리 receive 호출 필요 없음
- Viewer는 회원 모드와 동일하게 작동 (db가 아닌 로컬에 저장된 리스트를 읽음)
-------------------------
- PDF 뷰어가 파일을 읽을 수 있게 base64로 인코딩한 결과를 반환하도록 변경

Closes #28 